### PR TITLE
Response handle refactor

### DIFF
--- a/backend/datahubhel/settings.py
+++ b/backend/datahubhel/settings.py
@@ -122,6 +122,11 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticated',
     ],
+    'DEFAULT_RENDERER_CLASSES': [
+        'rest_framework.renderers.JSONRenderer',
+    ] + ([
+        'rest_framework.renderers.BrowsableAPIRenderer',
+    ] if DEBUG else []),
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework_jwt.authentication.JSONWebTokenAuthentication',
     ] + ([


### PR DESCRIPTION
This way we only return a `Response` object when handling JSON and and otherwise return something that is as close as possible to the response from the STS.