### PR TITLE
Mqtt dhh auth

### DIFF
--- a/backend/datahubhel/settings.py
+++ b/backend/datahubhel/settings.py
@@ -74,7 +74,6 @@ INSTALLED_APPS = [
     'rest_framework',
     'rest_framework.authtoken',
     'corsheaders',
-    'guardian',
     'django_extensions',
     'datahubhel',
     'gatekeeper',
@@ -123,7 +122,6 @@ AUTH_PASSWORD_VALIDATORS = [] if DEBUG else [
 
 AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',
-    'guardian.backends.ObjectPermissionBackend',
 ]
 
 REST_FRAMEWORK = {
@@ -186,6 +184,3 @@ LOGGING = {
 
 STA_VERSION = 'v1.0'
 GATEKEEPER_STS_BASE_URL = 'http://localhost:8080/FROST-Server'
-
-# GUARDIAN SETTINGS
-GUARDIAN_GET_INIT_ANONYMOUS_USER = 'dhh_auth.models.get_init_anonymous_user_instance'

--- a/backend/dhh_auth/models.py
+++ b/backend/dhh_auth/models.py
@@ -8,7 +8,6 @@ from django.db import models
 from django.db.models import QuerySet
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
-from guardian.conf import settings as guardian_settings
 
 from dhh_auth.utils import get_perm_obj
 from utils.models import TimestampedUUIDModel
@@ -167,14 +166,3 @@ class User(AbstractClientUser, PermissionsMixin):
         Sends an email to this User.
         """
         send_mail(subject, message, from_email, [self.email], **kwargs)
-
-
-def get_init_anonymous_user_instance(User):
-    client = Client.objects.create()
-    kwargs = {
-        User.USERNAME_FIELD: guardian_settings.ANONYMOUS_USER_NAME,
-        'client': client,
-    }
-    user = User(**kwargs)
-    user.set_unusable_password()
-    return user

--- a/backend/mqttauth/views.py
+++ b/backend/mqttauth/views.py
@@ -1,23 +1,18 @@
 import logging
 
 from django.conf import settings
-from django.contrib.auth import authenticate, get_user_model
+from django.contrib.auth import get_user_model
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
+from rest_framework import status
 
+from dhh_auth.models import ClientPermission
+from dhh_auth.utils import get_perm_obj
 from gatekeeper.models import Datastream
 from gatekeeper.utils import parse_sta_url
+from service.models import Service, ServiceToken
 
 logger = logging.getLogger(__name__)
-
-
-# TODO: Should be moved to a custom user manager when we have one
-def get_user_by_username_or_anonymous(username):
-    user_class = get_user_model()
-    try:
-        return user_class.objects.get(username=username, is_active=True)
-    except user_class.DoesNotExist:
-        return user_class.get_anonymous()
 
 
 @csrf_exempt
@@ -27,36 +22,49 @@ def auth(request):
     URI-Param           username   password    clientid    topic   acc
     http_getuser_uri    Y          Y           N           N       N
     """
-    response_status_code = 403
+    response_status_code = status.HTTP_403_FORBIDDEN
 
-    user = authenticate(request, username=request.POST.get('username'), password=request.POST.get('password'))
+    try:
+        ServiceToken.objects.get(service__identifier=request.POST.get('username'), service__is_active=True,
+                                 key=request.POST.get('password'))
 
-    # For now all registered users can connect
-    if user:
-        response_status_code = 200
+        response_status_code = status.HTTP_200_OK
+    except ServiceToken.DoesNotExist:
+        pass
 
-    logger.info('MQTT authentication for user "{}" {}'.format(
-        request.POST.get('username'), 'succeeded' if response_status_code == 200 else 'failed'))
+    logger.info('MQTT authentication for service "{}" {}'.format(
+        request.POST.get('username'), 'succeeded' if response_status_code == status.HTTP_200_OK else 'failed'))
 
     return HttpResponse(status=response_status_code)
 
 
 @csrf_exempt
 def superuser(request):
-    """Check superuser
+    """Check if the user with the supplied username is a superuser
+
+    Excludes any username that is an identifier of a service because
+    they could be mixed up and could end in a privilege escalation.
 
     URI-Param           username   password    clientid    topic   acc
     http_superuser_uri  Y          N           N           N       N
     """
-    response_status_code = 403
+    response_status_code = status.HTTP_403_FORBIDDEN
 
-    user = get_user_by_username_or_anonymous(request.POST.get('username'))
+    username = request.POST.get('username')
+    user = None
 
-    if user.is_superuser:
-        response_status_code = 200
+    user_class = get_user_model()
+    try:
+        service_identifiers = Service.objects.all().values_list('identifier', flat=True)
+        user = user_class.objects.exclude(username__in=service_identifiers).get(username=username, is_active=True)
+    except user_class.DoesNotExist:
+        pass
+
+    if user and user.is_superuser:
+        response_status_code = status.HTTP_200_OK
 
     logger.info('MQTT is super user check for user "{}": {}'.format(
-        request.POST.get('username'), 'True' if response_status_code == 200 else 'False'))
+        username, 'True' if response_status_code == status.HTTP_200_OK else 'False'))
 
     return HttpResponse(status=response_status_code)
 
@@ -68,7 +76,7 @@ def acl(request):
     URI-Param           username   password    clientid    topic   acc
     http_aclcheck_uri   Y          N           Y           Y       Y
     """
-    response_status_code = 403
+    response_status_code = status.HTTP_403_FORBIDDEN
 
     username = request.POST.get('username')
     topic = request.POST.get('topic')
@@ -76,8 +84,8 @@ def acl(request):
     acc = request.POST.get('acc')  # 1 == sub, 2 == pub
 
     permission_name_map = {
-        '1': 'subscribe_datastream',
-        '2': 'publish_datastream',
+        '1': 'view_datastream',
+        '2': 'create_observation',
     }
 
     permission_name = permission_name_map.get(acc)
@@ -85,28 +93,32 @@ def acl(request):
         logger.info('MQTT ACL check encountered unknown value for acc: "{}"'.format(acc))
         return HttpResponse(status=response_status_code)
 
-    log_text = 'MQTT ACL check for user "{}", topic "{}", perm "{}". Result: '.format(username, topic, permission_name)
+    log_text = 'MQTT ACL check for service "{}", topic "{}", perm "{}". Result: '.format(
+        username, topic, permission_name)
 
-    user = get_user_by_username_or_anonymous(username)
-
-    if user.is_superuser:
-        logger.info(log_text + 'Access granted (superuser)')
-        return HttpResponse(status=200)
+    try:
+        service = Service.objects.get(identifier=username)
+    except Service.DoesNotExist:
+        logger.info(log_text + 'Unknown service.')
+        return HttpResponse(status=response_status_code)
 
     parse_result = parse_sta_url(topic, prefix=settings.STA_VERSION)
 
-    if parse_result['parts']:
+    if parse_result and parse_result['parts']:
         # For now we only look for a Datastream id and check permissions for that datastream
         for part in parse_result['parts']:
             if part['type'] == 'entity' and part['name'] == 'Datastream' and part['id']:
                 try:
                     ds = Datastream.objects.get(sts_id=part['id'])
+                    permission = get_perm_obj(permission_name, Datastream)
 
-                    if user.has_perm(permission_name, ds):
-                        response_status_code = 200
-                except Datastream.DoesNotExist:
+                    ClientPermission.objects.get(permission=permission, client=service.client,
+                                                 content_type=permission.content_type, object_pk=ds.id)
+
+                    response_status_code = status.HTTP_200_OK
+                except (Datastream.DoesNotExist, ClientPermission.DoesNotExist):
                     pass
 
-    logger.info(log_text + ('Access granted' if response_status_code == 200 else 'Access denied'))
+    logger.info(log_text + ('Access granted' if response_status_code == status.HTTP_200_OK else 'Access denied'))
 
     return HttpResponse(status=response_status_code)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,7 +10,6 @@ django-cors-headers==2.1.0
 django-enumfields==0.9.0
 django-environ==0.4.4
 django-extensions==1.9.9
-django-guardian==1.4.9
 djangorestframework==3.7.7
 djangorestframework-jwt==1.11.0
 drf-enum-field==0.9.2
@@ -20,6 +19,6 @@ pyjwt==1.5.3              # via djangorestframework-jwt
 pytz==2018.3              # via django
 raven==6.5.0
 requests==2.18.4
-six==1.11.0               # via django-environ, django-extensions, django-guardian
+six==1.11.0               # via django-environ, django-extensions
 typing==3.6.2             # via django-extensions
 urllib3==1.22             # via requests

--- a/backend/setup.cfg
+++ b/backend/setup.cfg
@@ -32,7 +32,6 @@ requirements =
     django-enumfields
     django-environ
     django-extensions
-    django-guardian
     djangorestframework
     djangorestframework-jwt
     Django~=2.0.0


### PR DESCRIPTION
Change mqttauth acl endpoint to use dhh_auth ClientPermission instead of django-guardian. Additionally the auth endpoint checks for Service identifier and token instead of User's username and password.